### PR TITLE
Fix for missing search results.

### DIFF
--- a/Audible.com#Search by Album.src
+++ b/Audible.com#Search by Album.src
@@ -31,10 +31,15 @@
 #DebugWriteInput #"C:\Users\%user%\Desktop\mp3tag.html"
 #Debug "ON" #"C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
-joinuntil "</html>"
-regexpreplace "[\r\n]+" ""
-regexpreplace ".+results" "results"
-regexpreplace "<script asyn.+" ""
+#Only select the area we need instead of everyting.
+findline "<ul  class=\"bc-list"
+joinuntil "center-4"
+
+#These are no longer needed from what I can tell.
+#regexpreplace "[\r\n]+" ""
+#regexpreplace ".+results" "results"
+#regexpreplace "<script asyn.+" ""
+
 regexpreplace "\s\s+" " "
 regexpreplace "\t+" " "
 replace "\" >" "\">"


### PR DESCRIPTION
previous version was bugged where any search that had the words "results" in the title or description would cause everything up to that point to be removed.