### PR TITLE
Fixed for Issue #28

### DIFF
--- a/Audible.co.jp#Search by Album.src
+++ b/Audible.co.jp#Search by Album.src
@@ -33,7 +33,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "

--- a/Audible.co.uk#Search by Album.src
+++ b/Audible.co.uk#Search by Album.src
@@ -32,7 +32,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "

--- a/Audible.com#Search by Album - BETA.src
+++ b/Audible.com#Search by Album - BETA.src
@@ -32,7 +32,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "

--- a/Audible.com#Search by Album.src
+++ b/Audible.com#Search by Album.src
@@ -32,7 +32,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "

--- a/Audible.com#Search by Filename.src
+++ b/Audible.com#Search by Filename.src
@@ -32,7 +32,7 @@
 #Debug "ON" #"C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "

--- a/Audible.com.au#Search by Album.src
+++ b/Audible.com.au#Search by Album.src
@@ -33,7 +33,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "

--- a/Audible.de#Search by Album.src
+++ b/Audible.de#Search by Album.src
@@ -33,7 +33,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "<ul  class=\"bc-list"
+findline "center-3"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "


### PR DESCRIPTION
heres a temp fix. it changes where it starts pulling info for the index by changing the part from "<ul class="bc-list" to "center-3" for whatever reason, maybe amazon changed something, but it's now including the first category as the first book entry in the index table. by changing it to center-3, it selects the area past the section causing the problem, making it function again.

i've tested this on 5 books, some solo books and some in series and it seems to resolve the issue for now.