### PR TITLE
Fix scripts

### DIFF
--- a/Audible.co.jp#Search by Album.src
+++ b/Audible.co.jp#Search by Album.src
@@ -8,6 +8,7 @@
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
 # 2021-10-15: Updated to support Audible.co.jp (u/MrPiethon) 
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -33,7 +34,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -42,7 +43,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Running Time:" ""
 
-findinline "results"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -116,8 +117,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1

--- a/Audible.co.uk#Search by Album.src
+++ b/Audible.co.uk#Search by Album.src
@@ -7,6 +7,7 @@
 # 2020-04-06: Updated to Audible.com
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -32,7 +33,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -41,7 +42,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Running Time:" ""
 
-findinline "results"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -115,8 +116,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1

--- a/Audible.com#Search by Album - BETA.src
+++ b/Audible.com#Search by Album - BETA.src
@@ -7,6 +7,7 @@
 # 2020-04-06: Updated to Audible.com
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -32,7 +33,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -41,7 +42,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Running Time:" ""
 
-findinline "results"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -115,8 +116,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1

--- a/Audible.com#Search by Album.src
+++ b/Audible.com#Search by Album.src
@@ -7,6 +7,7 @@
 # 2020-04-06: Updated to Audible.com
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -32,7 +33,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -41,7 +42,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Running Time:" ""
 
-findinline "results"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -115,8 +116,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1

--- a/Audible.com#Search by Filename.src
+++ b/Audible.com#Search by Filename.src
@@ -7,6 +7,7 @@
 # 2020-04-06: Updated to Audible.com
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -32,7 +33,7 @@
 #Debug "ON" #"C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -41,7 +42,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Running Time:" ""
 
-findinline "results"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -115,8 +116,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1

--- a/Audible.com.au#Search by Album.src
+++ b/Audible.com.au#Search by Album.src
@@ -8,6 +8,7 @@
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
 # 2021-12-07: Updated to Audible.com.au
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -33,7 +34,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -42,7 +43,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Running Time:" ""
 
-findinline "results"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -116,8 +117,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1

--- a/Audible.de#Search by Album.src
+++ b/Audible.de#Search by Album.src
@@ -8,6 +8,7 @@
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
 # 2021-05-27: Changed back to Audible.de
+# 2023-08-11: Updated (u/d-e-x-x)
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -33,7 +34,7 @@
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
 #Only select the area we need instead of everyting.
-findline "center-3"
+findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
 regexpreplace "\s\s+" " "
@@ -42,7 +43,7 @@ replace "\" >" "\">"
 replace "> <" "><"
 replace "Spieldauer:" ""
 
-findinline "resultsSummarySubheading"
+findinline "bc-spacing-micro"
 findinline "<h3 class=\"bc-heading"
 
 do
@@ -115,8 +116,8 @@ sayuntil "\""
 gotoline 1
 
 # Asin
-findline "<input type=\"hidden\" name=\"asin\" value=\""
-findinline "<input type=\"hidden\" name=\"asin\" value=\""
+findline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
+findinline "<input type=\"hidden\" id=\"reviewsAsinUS\" value=\""
 outputto "ASIN"
 sayuntil "\""
 gotoline 1


### PR DESCRIPTION
Fix album parse and replace `center-3` index hack.

Fixes https://github.com/seanap/Audible.com-Search-by-Album/issues/33 https://github.com/seanap/Audible.com-Search-by-Album/issues/31
Related to https://github.com/seanap/Audible.com-Search-by-Album/issues/28