### PR TITLE
Spelling Error Fix & Fixing Cover Images

### DIFF
--- a/Audible.com#Search by Album.src
+++ b/Audible.com#Search by Album.src
@@ -8,6 +8,7 @@
 # 2020-06-28: Updated to region independent (u/Carlyone)
 # 2020-08-05: Updated
 # 2023-08-11: Updated (u/d-e-x-x)
+# 2023-10-16: Updated to fix cover image
 #
 # This file should be in your sources dir. %appdata%\roaming\mp3tag\data\sources
 # On Windows XP it's C:\Documents and Settings\*username*\Application Data\Mp3tag\data\sources
@@ -32,7 +33,7 @@
 #DebugWriteInput "C:\Users\%user%\Desktop\mp3tag.html"
 #Debug "ON" "C:\Users\%user%\Desktop\mp3tagdebug.txt"
 
-#Only select the area we need instead of everyting.
+#Only select the area we need instead of everything.
 findline "<ul  class=\"bc-list"
 joinuntil "center-4"
 
@@ -293,7 +294,7 @@ else
 	findline ", \"description\": \"" 1 1
 	unspace
 	if ", \"description\": \""
-		outputto "Comment"
+		outputto "Description"
 		findinline ", \"description\": \""
 		unspace
 		joinuntil ", \"image"
@@ -303,6 +304,11 @@ else
 		regexpreplace "  +" " "
 		replace ", \"description\": \"" ""
 		sayuntil ", \"image"
+		findline ", \"image\": \""
+		unspace
+		findinline ": \""
+		outputto "Coverurl"
+		sayuntil "\""
 		findline ", \"publisher\": \""
 		unspace
 		findinline ": \""


### PR DESCRIPTION
Fixed a spelling error early in the code (small, but I couldn't commit code and not suggest it)

I couldn't get the covers to work at all - I ended up running the debugger and found where it removed it. I added it in so that the image now works properly.

I personally changed "comment" to "description" but that was a personal change - I didn't mean to commit that specifically